### PR TITLE
Add id_token to ExtraLoginOptions

### DIFF
--- a/core/src/main/java/com/web3auth/core/types/ExtraLoginOptions.kt
+++ b/core/src/main/java/com/web3auth/core/types/ExtraLoginOptions.kt
@@ -11,6 +11,7 @@ data class ExtraLoginOptions(
     private var prompt : Prompt? = null,
     private var max_age : String? = null,
     private var ui_locales : String? = null,
+    private var id_token : String? = null,
     private var id_token_hint : String? = null,
     private var login_hint : String? = null,
     private var acr_values : String? = null,


### PR DESCRIPTION
Required to support arbitrary JWT login in Android.

Seems to already be present in the Swift SDK so I guess it's fine to add it here.

https://github.com/Web3Auth/web3auth-swift-sdk/blob/master/Sources/Web3Auth/Types.swift#L252